### PR TITLE
Ignore '.*env' files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ build/
 # ignore Rake task artifact
 payload
 
+.*env


### PR DESCRIPTION
so that `TRAVIS_TOKEN` may be defined in `.env`
