### PR TITLE
Make it possible to set mulitple global env vars

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task :build, [:repo, :branch, :extra] do |_t, args|
   config = {}
 
   if args[:extra]
-    config = { 'env' => { 'global' => [args[:extra]] } }
+    config = { 'env' => { 'global' => args[:extra].split } }
     message = format(message, "; (#{args[:extra]})")
   else
     message = format(message, nil)


### PR DESCRIPTION
To do this, pass space-delimited list to the last
arg in a single quote; e.g.,

```
bundle exec rake build[php-src-builder,version,'VERSION=7.0snapshot ALIAS=$VERSION']
```
