### PR TITLE
Add Perl support for 5.27 and 5.28

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ RUNTIMES = {
     api_path: 'repos/Perl/perl5/tags',
     version_prefix: 'v',
     except: 'v(\d+)\.\d*[13579](\.\d+)(-RC\d+)?$',
-    supported_major_minor: %w(5.24 5.26),
+    supported_major_minor: %w(5.24 5.26 5.27 5.28),
   ),
   'perl-extras' => OpenStruct.new(
     archive_bucket: 'travis-perl-archives',


### PR DESCRIPTION
See: https://dev.perl.org/perl5/

Perl versions > 5.26 aren't installed at the moment:

```

I, [2018-08-19T05:52:22.179425 #3009]  INFO -- : Building latest archives for perl
I, [2018-08-19T05:52:23.287128 #3009]  INFO -- : latest_archives[major_minor]=5.26.2
I, [2018-08-19T05:52:23.287186 #3009]  INFO -- : vers=5.26.2
I, [2018-08-19T05:52:23.287209 #3009]  INFO -- : perl 5.26 is up to date (5.26.2)
```
(https://travis-ci.org/travis-ci/travis-nightly-builder/jobs/417808428)