### PR TITLE
Bump rack version for security patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       ast (~> 2.2)
     powerpack (0.1.1)
     puma (3.8.2)
-    rack (1.6.8)
+    rack (1.6.11)
     rack-protection (1.5.3)
       rack
     rack-ssl (1.4.1)
@@ -85,4 +85,4 @@ DEPENDENCIES
   sinatra-param
 
 BUNDLED WITH
-   1.14.6
+   1.16.3


### PR DESCRIPTION
rack:
https://nvd.nist.gov/vuln/detail/CVE-2018-16470
https://nvd.nist.gov/vuln/detail/CVE-2018-16471

Note that I opened this PR against `master` but if it needs to be against `build` let me know, I'll resubmit it.