### PR TITLE
Build Ruby 2.7.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -133,7 +133,7 @@ RUNTIMES = {
     repo: 'ruby/ruby',
     api_path: 'repos/ruby/ruby/tags',
     version_prefix: 'v',
-    supported_major_minor: ['2.2', '2.3', '2.4', '2.5', '2.6'],
+    supported_major_minor: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7'],
     pass_through_release_name: true,
     skip_matching_alias: true,
     release_transformer: -> before { before.gsub('_', '.') },


### PR DESCRIPTION
This pull request adds 2.7 to the list of supported Ruby versions. This will allow today's v2.7.1 release to be picked up and built (it looks like the [v2.7.0 build](https://travis-ci.com/github/travis-ci/travis-rubies/builds/142324390) was started manually).