### PR TITLE
Build 3.10-dev as nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,10 @@ jobs:
       name: 3.7-dev
     - script: bundle exec rake build['cpython-builder','default','VERSION=3.8-dev']
       name: 3.8-dev
-    - script: bundle exec rake build['cpython-builder','default','VERSION=3.9-dev ALIAS=nightly']
+    - script: bundle exec rake build['cpython-builder','default','VERSION=3.9-dev']
       name: 3.9-dev
+    - script: bundle exec rake build['cpython-builder','default','VERSION=3.10-dev ALIAS=nightly']
+      name: 3.10-dev
     - script: bundle exec rake build['cpython-builder','default','VERSION=pypy3-dev ALIAS=pypy3-nightly']
       name: pypy3-dev
     - script: bundle exec rake build['cpython-builder','default','VERSION=pypy-dev ALIAS=pypy-nightly']


### PR DESCRIPTION
Python 3.9 beta was released yesterday:

* https://www.python.org/downloads/release/python-390b1/

Which means the Python 3.10 branch is now open for business:

* https://github.com/python/cpython/pull/20198

This adds `3.10-dev` and sets it to `nightly`, following the same pattern as https://github.com/travis-ci/travis-nightly-builder/commit/41c2123408374d96044986ef1347427e5c38f5ac for Python `3.9-dev` (via https://travis-ci.community/t/python-3-9-support/6703).

